### PR TITLE
Update missing Angular 4 dependencies

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -19,12 +19,12 @@
   "module": "ngx-loggly-logger.js",
   "typings": "ngx-loggly-logger.d.ts",
   "peerDependencies": {
-    "@angular/core": "^4.0.0",
-    "rxjs": "^5.1.0",
-    "zone.js": "^0.8.4"
+    "@angular/core": "^5.0.2",
+    "rxjs": "^5.5.2",
+    "zone.js": "^0.8.18"
   },
   "dependencies": {
-    "@angular/http": "^4.0.3",
-    "ng2-cookies": "^1.0.11"
+    "@angular/http": "^5.0.2",
+    "ng2-cookies": "^1.0.12"
   }
 }


### PR DESCRIPTION
Updating a personal project to Angular 5, i realized that some dependencies were still pointing to Angular 4 version. This request updates all versions based on project root's package.json file.